### PR TITLE
Petite erreur dans HughesPlane

### DIFF
--- a/hughes.py
+++ b/hughes.py
@@ -81,7 +81,7 @@ def HughesPlane(n2):
             l=[]
             l.append(vector((-a,K(1),K(0))))
             for x in v:
-                if ~a*(-x-K(1)).is_square():
+                if (~a*(-x-K(1))).is_square():
                     l.append(vector((x,~a*(-x-K(1)),K(1))))
                 else:
                     l.append(vector((x,~a **n * (-x-K(1)),K(1))))


### PR DESCRIPTION
Probleme de priorite d'operateur... les deux operations suivantes ne
sont pas equivalentes:

   ~a.b()   et    (~a).b()
